### PR TITLE
Added burn instruction to transaction

### DIFF
--- a/src/views/BurnNFTView/index.tsx
+++ b/src/views/BurnNFTView/index.tsx
@@ -215,6 +215,12 @@ export const BurnNFTView: FC = ({}) => {
                     splTokenProgram: TOKEN_PROGRAM_ID,
                     collectionMetadata: collectionMetadata,
                   };
+                  const burnInstruction = createBurnNftInstruction(
+                    burnAccount,
+                    new PublicKey(PROGRAM_ADDRESS)
+                  );
+                  // add the burn instruction to the transaction
+                  Tx.add(burnInstruction);
                 } else {
                   burnAccount = {
                     metadata: metadataAccount,


### PR DESCRIPTION
With this commit we correct the wrong behavior when burning NFTs under certain conditions, where burn instruction was not finally included in the transaction.

Apparently, this behavior was introduced with commit https://github.com/cryptoloutre/solana-tools/commit/598722001359be35e206fd919dfcf6b83dae9a19

Closes #6 